### PR TITLE
feat(Auth): adapter les champs existants au contexte universitaire - …

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -603,8 +603,9 @@ class Config extends CommonDBTM
         echo "<tr><th colspan='4'>" . __('Authentication') . "</th></tr>";
 
         echo "<tr class='tab_bg_2'>";
-        echo "<td width='30%'>" . __('Automatically add users from an external authentication source') .
-           "</td><td width='20%'>";
+        echo "<td width='30%'>" . __('Automatically add users from an external authentication source');
+        Html::showToolTip(__('Synchronisation automatique avec l\'annuaire universitaire (LDAP/Active Directory)'));
+        echo "</td><td width='20%'>";
         Dropdown::showYesNo("is_users_auto_add", $CFG_GLPI["is_users_auto_add"]);
         echo "</td><td width='30%'>" . __('Add a user without accreditation from a LDAP directory') .
            "</td><td width='20%'>";
@@ -612,7 +613,9 @@ class Config extends CommonDBTM
         echo "</td></tr>";
 
         echo "<tr class='tab_bg_2'>";
-        echo "<td> " . __('Action when a user is deleted from the LDAP directory') . "</td><td>";
+        echo "<td> " . __('Action when a user is deleted from the LDAP directory');
+        Html::showToolTip(__('Action lors de la suppression d\'un étudiant/personnel de l\'annuaire universitaire'));
+        echo "</td><td>";
         AuthLDAP::dropdownUserDeletedActions($CFG_GLPI["user_deleted_ldap"]);
         echo "</td><td> " . __('Action when a user is restored in the LDAP directory') . "</td><td>";
         AuthLDAP::dropdownUserRestoredActions($CFG_GLPI["user_restored_ldap"]);


### PR DESCRIPTION
## Objectif
Modifier uniquement les champs déjà présents dans l’onglet Configuration > Authentification pour qu’ils soient formulés dans un contexte universitaire (étudiants, personnel, annuaire).

## Périmètre
- Aucun nouveau champ.
- Uniquement des changements de libellés et de textes d’aide (helper texts) dans la méthode `showFormAuthentication()` du fichier `src/Config.php`.

## Modifications prévues
- **« Automatically add users from an external authentication source »**  
  Ajouter ou modifier le helper text pour : « Synchronisation automatique avec l’annuaire universitaire (LDAP/Active Directory) ».
- **« Action when a user is deleted from the LDAP directory »**  
  Ajouter ou modifier le helper text pour : « Action lors de la suppression d’un étudiant/personnel de l’annuaire universitaire ».
- Autres champs existants (optionnel) : adapter les libellés ou helper texts si des formulations « université / étudiants / personnel » sont jugées utiles.

## Fichiers impactés
- `src/Config.php` (méthode `showFormAuthentication()`).

## Critères de validation
- Les helper texts s’affichent correctement à l’affichage du formulaire.
- Aucune régression sur le comportement de sauvegarde des champs existants.