### PR TITLE
Update CI deploy branch to pre-product

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
     name: Deploy to Development
     runs-on: ubuntu-latest
     needs: [build, integration-tests]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/configmysqlcicd_k'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/pre-product'
     environment: development
     
     steps:


### PR DESCRIPTION
Modify .github/workflows/ci.yml to change the Deploy to Development job's branch filter: the job now runs on pushes to refs/heads/pre-product instead of refs/heads/configmysqlcicd_k, ensuring deployments are triggered from the pre-product branch.