### PR TITLE
merge(assistance): promote Technical Support/FAQ fixes and i18n coverage from groupe_assistance

### DIFF
--- a/front/helpdesk.php
+++ b/front/helpdesk.php
@@ -35,7 +35,9 @@
 
 include('../inc/includes.php');
 
-if ((int)$CFG_GLPI['use_anonymous_helpdesk'] === 0) {
+// Keep anonymous users out when anonymous helpdesk is disabled, but allow
+// authenticated users to access the Technical Support page from Assistance.
+if ((int)$CFG_GLPI['use_anonymous_helpdesk'] === 0 && !Session::getLoginUserID()) {
     Html::redirect($CFG_GLPI["root_doc"] . "/front/central.php");
 }
 

--- a/front/inventoryorganization.coherence.php
+++ b/front/inventoryorganization.coherence.php
@@ -68,9 +68,9 @@ $summary = [
 
 // Get issue types for filter
 $issue_types = [
-    'no_location'     => 'Aucun lieu assigné',
-    'root_entity'     => 'Dans l\'entité racine',
-    'duplicate_serial' => 'Numéro de série dupliqué',
+    'no_location'      => __('No location assigned'),
+    'root_entity'      => __('In root entity'),
+    'duplicate_serial' => __('Duplicate serial number'),
 ];
 
 // Export functionality
@@ -82,11 +82,11 @@ if (isset($_GET['export']) && $_GET['export'] === 'csv') {
     
     // CSV header
     fputcsv($output, [
-        'Sévérité',
-        'Type',
-        'Message',
-        'Type d\'Actif',
-        'Nom de l\'Actif',
+        __('Severity'),
+        __('Type'),
+        __('Message'),
+        __('Asset Type'),
+        __('Asset Name'),
     ]);
     
     // CSV data
@@ -106,7 +106,7 @@ if (isset($_GET['export']) && $_GET['export'] === 'csv') {
 
 // Display header
 Html::header(
-    'Vérification de la Cohérence de l\'Inventaire',
+    __('Inventory Coherence Check'),
     $_SERVER['PHP_SELF'],
     'helpdesk',
     'inventoryorganization'
@@ -114,7 +114,7 @@ Html::header(
 
 // Render the coherence check template
 Glpi\Application\View\TemplateRenderer::getInstance()->display('pages/inventoryorganization/coherence.html.twig', [
-    'title'           => 'Vérification de la Cohérence de l\'Inventaire',
+    'title'           => __('Inventory Coherence Check'),
     'issues'          => array_values($issues),
     'summary'         => $summary,
     'issue_types'     => $issue_types,

--- a/front/inventoryorganization.labeling.php
+++ b/front/inventoryorganization.labeling.php
@@ -71,16 +71,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         
         // Validate prefix
         if (empty($new_config['prefix'])) {
-            $error_message = 'Le préfixe est requis';
+            $error_message = __('Prefix is required');
         } elseif (!preg_match('/^[A-Z]{2,5}$/', $new_config['prefix'])) {
-            $error_message = 'Le préfixe doit être de 2 à 5 lettres majuscules';
+            $error_message = __('Prefix must be between 2 and 5 uppercase letters');
         } else {
             if (InventoryOrganization::saveLabelingConfig($new_config)) {
                 $success = true;
                 $config = $new_config;
-                Session::addMessageAfterRedirect('Configuration de l\'étiquetage enregistrée', false, INFO);
+                Session::addMessageAfterRedirect(__('Labeling configuration saved'), false, INFO);
             } else {
-                $error_message = 'Échec de l\'enregistrement de la configuration';
+                $error_message = __('Failed to save configuration');
             }
         }
     }
@@ -99,7 +99,7 @@ foreach ($asset_types as $type) {
 
 // Display header
 Html::header(
-    'Configuration de l\'Étiquetage',
+    __('Labeling Configuration'),
     $_SERVER['PHP_SELF'],
     'helpdesk',
     'inventoryorganization'
@@ -107,20 +107,20 @@ Html::header(
 
 // Render the labeling configuration template
 Glpi\Application\View\TemplateRenderer::getInstance()->display('pages/inventoryorganization/labeling.html.twig', [
-    'title'          => 'Configuration de l\'Étiquetage',
+    'title'          => __('Labeling Configuration'),
     'config'         => $config,
     'preview_labels' => $preview_labels,
     'success'        => $success,
     'error_message'  => $error_message,
     'can_create'     => InventoryOrganization::canCreate(),
     'asset_types'    => [
-        'computer'   => 'Ordinateur',
-        'laptop'     => 'Laptop',
-        'monitor'    => 'Moniteur',
-        'printer'    => 'Imprimante',
-        'phone'      => 'Téléphone',
-        'projector'  => 'Vidéoprojecteur',
-        'peripheral' => 'Périphérique',
+        'computer'   => __('Computer'),
+        'laptop'     => __('Laptop'),
+        'monitor'    => __('Monitor'),
+        'printer'    => __('Printer'),
+        'phone'      => __('Phone'),
+        'projector'  => __('Projector'),
+        'peripheral' => __('Peripheral'),
     ],
 ]);
 

--- a/front/inventoryorganization.location.php
+++ b/front/inventoryorganization.location.php
@@ -63,7 +63,7 @@ $flat_locations = flattenLocations($locations);
 
 // Display header
 Html::header(
-    'Gestion des Lieux',
+    __('Location Management'),
     $_SERVER['PHP_SELF'],
     'helpdesk',
     'inventoryorganization'
@@ -71,7 +71,7 @@ Html::header(
 
 // Render the location management template
 Glpi\Application\View\TemplateRenderer::getInstance()->display('pages/inventoryorganization/locations.html.twig', [
-    'title'          => 'Gestion des Lieux',
+    'title'          => __('Location Management'),
     'locations'      => $locations,
     'flat_locations' => $flat_locations,
     'entities'       => $flat_entities,

--- a/front/inventoryorganization.type.php
+++ b/front/inventoryorganization.type.php
@@ -54,7 +54,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $type_name = trim($_POST['type_name'] ?? '');
         
         if (empty($type_name)) {
-            $error_message = 'Le nom du type est requis';
+            $error_message = __('Type name is required');
         } else {
             // Create the type based on category
             $type_classes = [
@@ -76,12 +76,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($type_obj->add($input)) {
                 $success = true;
                 Session::addMessageAfterRedirect(
-                    sprintf('Type "%s" créé avec succès', $type_name),
+                    sprintf(__('Type "%s" created successfully'), $type_name),
                     false,
                     INFO
                 );
             } else {
-                $error_message = 'Échec de la création du type';
+                $error_message = __('Failed to create type');
             }
         }
     }
@@ -103,9 +103,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $type_obj = new $class_name();
             
             if ($type_obj->delete(['id' => $type_id])) {
-                Session::addMessageAfterRedirect('Type supprimé avec succès', false, INFO);
+                Session::addMessageAfterRedirect(__('Type deleted successfully'), false, INFO);
             } else {
-                Session::addMessageAfterRedirect('Échec de la suppression du type', false, ERROR);
+                Session::addMessageAfterRedirect(__('Failed to delete type'), false, ERROR);
             }
         }
         Html::redirect($_SERVER['PHP_SELF']);
@@ -117,16 +117,16 @@ $types = InventoryOrganization::getMaterialTypes();
 
 // Prepare type categories for the form
 $type_categories = [
-    'computer'   => 'Ordinateurs',
-    'monitor'    => 'Moniteurs',
-    'printer'    => 'Imprimantes',
-    'phone'      => 'Téléphones',
-    'peripheral' => 'Périphériques',
+    'computer'   => __('Computers'),
+    'monitor'    => __('Monitors'),
+    'printer'    => __('Printers'),
+    'phone'      => __('Phones'),
+    'peripheral' => __('Peripherals'),
 ];
 
 // Display header
 Html::header(
-    'Gestion des Types de Matériel',
+    __('Material Type Management'),
     $_SERVER['PHP_SELF'],
     'helpdesk',
     'inventoryorganization'
@@ -134,7 +134,7 @@ Html::header(
 
 // Render the type management template
 Glpi\Application\View\TemplateRenderer::getInstance()->display('pages/inventoryorganization/types.html.twig', [
-    'title'           => 'Gestion des Types de Matériel',
+    'title'           => __('Material Type Management'),
     'types'           => $types,
     'type_categories' => $type_categories,
     'success'         => $success,

--- a/locales/en_US.po
+++ b/locales/en_US.po
@@ -26364,3 +26364,85 @@ msgstr "Info"
 #: common
 msgid "Type"
 msgstr "Type"
+
+#. UNH GLPI Custom Translations - Inventory Organization (PHP front files)
+#: front/inventoryorganization.type.php
+msgid "Type name is required"
+msgstr "Type name is required"
+
+#: front/inventoryorganization.type.php
+#, php-format
+msgid "Type \"%s\" created successfully"
+msgstr "Type \"%s\" created successfully"
+
+#: front/inventoryorganization.type.php
+msgid "Failed to create type"
+msgstr "Failed to create type"
+
+#: front/inventoryorganization.type.php
+msgid "Type deleted successfully"
+msgstr "Type deleted successfully"
+
+#: front/inventoryorganization.type.php
+msgid "Failed to delete type"
+msgstr "Failed to delete type"
+
+#: front/inventoryorganization.type.php
+msgid "Material Type Management"
+msgstr "Material Type Management"
+
+#: front/inventoryorganization.location.php
+msgid "Location Management"
+msgstr "Location Management"
+
+#: front/inventoryorganization.labeling.php
+msgid "Prefix is required"
+msgstr "Prefix is required"
+
+#: front/inventoryorganization.labeling.php
+msgid "Prefix must be between 2 and 5 uppercase letters"
+msgstr "Prefix must be between 2 and 5 uppercase letters"
+
+#: front/inventoryorganization.labeling.php
+msgid "Labeling configuration saved"
+msgstr "Labeling configuration saved"
+
+#: front/inventoryorganization.labeling.php
+msgid "Failed to save configuration"
+msgstr "Failed to save configuration"
+
+#: front/inventoryorganization.coherence.php
+msgid "No location assigned"
+msgstr "No location assigned"
+
+#: front/inventoryorganization.coherence.php
+msgid "In root entity"
+msgstr "In root entity"
+
+#: front/inventoryorganization.coherence.php
+msgid "Duplicate serial number"
+msgstr "Duplicate serial number"
+
+#: front/inventoryorganization.coherence.php
+msgid "Inventory Coherence Check"
+msgstr "Inventory Coherence Check"
+
+#: front/inventoryorganization.labeling.php
+msgid "Laptop"
+msgstr "Laptop"
+
+#: front/inventoryorganization.labeling.php
+msgid "Peripheral"
+msgstr "Peripheral"
+
+#: front/inventoryorganization.labeling.php
+msgid "Projector"
+msgstr "Projector"
+
+#: front/inventoryorganization.type.php
+msgid "Phones"
+msgstr "Phones"
+
+#: front/inventoryorganization.type.php
+msgid "Peripherals"
+msgstr "Peripherals"

--- a/locales/fr_FR.po
+++ b/locales/fr_FR.po
@@ -27356,6 +27356,88 @@ msgstr "Info"
 msgid "Type"
 msgstr "Type"
 
+#. UNH GLPI Custom Translations - Inventory Organization (PHP front files)
+#: front/inventoryorganization.type.php
+msgid "Type name is required"
+msgstr "Le nom du type est requis"
+
+#: front/inventoryorganization.type.php
+#, php-format
+msgid "Type \"%s\" created successfully"
+msgstr "Type \"%s\" créé avec succès"
+
+#: front/inventoryorganization.type.php
+msgid "Failed to create type"
+msgstr "Échec de la création du type"
+
+#: front/inventoryorganization.type.php
+msgid "Type deleted successfully"
+msgstr "Type supprimé avec succès"
+
+#: front/inventoryorganization.type.php
+msgid "Failed to delete type"
+msgstr "Échec de la suppression du type"
+
+#: front/inventoryorganization.type.php
+msgid "Material Type Management"
+msgstr "Gestion des types de matériel"
+
+#: front/inventoryorganization.location.php
+msgid "Location Management"
+msgstr "Gestion des lieux"
+
+#: front/inventoryorganization.labeling.php
+msgid "Prefix is required"
+msgstr "Le préfixe est requis"
+
+#: front/inventoryorganization.labeling.php
+msgid "Prefix must be between 2 and 5 uppercase letters"
+msgstr "Le préfixe doit être de 2 à 5 lettres majuscules"
+
+#: front/inventoryorganization.labeling.php
+msgid "Labeling configuration saved"
+msgstr "Configuration de l'étiquetage enregistrée"
+
+#: front/inventoryorganization.labeling.php
+msgid "Failed to save configuration"
+msgstr "Échec de l'enregistrement de la configuration"
+
+#: front/inventoryorganization.coherence.php
+msgid "No location assigned"
+msgstr "Aucun lieu assigné"
+
+#: front/inventoryorganization.coherence.php
+msgid "In root entity"
+msgstr "Dans l'entité racine"
+
+#: front/inventoryorganization.coherence.php
+msgid "Duplicate serial number"
+msgstr "Numéro de série dupliqué"
+
+#: front/inventoryorganization.coherence.php
+msgid "Inventory Coherence Check"
+msgstr "Vérification de la cohérence de l'inventaire"
+
+#: front/inventoryorganization.labeling.php
+msgid "Laptop"
+msgstr "Ordinateur portable"
+
+#: front/inventoryorganization.labeling.php
+msgid "Peripheral"
+msgstr "Périphérique"
+
+#: front/inventoryorganization.labeling.php
+msgid "Projector"
+msgstr "Vidéoprojecteur"
+
+#: front/inventoryorganization.type.php
+msgid "Phones"
+msgstr "Téléphones"
+
+#: front/inventoryorganization.type.php
+msgid "Peripherals"
+msgstr "Périphériques"
+
 #: templates/pages/inventoryorganization/locations.html.twig
 msgid "Location created successfully!"
 msgstr "Lieu créé avec succès !"

--- a/src/Html.php
+++ b/src/Html.php
@@ -1572,7 +1572,7 @@ HTML;
                 $menu['helpdesk']['content']['faq'] = [
                     'title'    => __('FAQ'),
                     'shortcut' => 'b',
-                    'page'     => '/front/knowbaseitem.php',
+                    'page'     => '/front/helpdesk.faq.php',
                     'icon'     => 'ti ti-book',
                 ];
             }


### PR DESCRIPTION
## Objectif
Promotion des correctifs du module Assistance vers `pre-product`.

## Inclus
- Correctif accès `Technical Support` pour utilisateurs connectés
- Correction routing FAQ (`Assistance > FAQ` vers `helpdesk.faq.php`)
- Corrections i18n (suppression des chaînes codées en dur dans Inventory Organization)
- Ajout/alignement des traductions `fr_FR.po` et `en_US.po`
- Correction encodage FAQ (réimport en UTF-8 côté DB)

## Tests exécutés avant promotion
- `php -l front/helpdesk.php` 
- `php -l src/Html.php` 
- `php tests/HtmlMenuUnitTest.php`  (4/4)
- `php tests/TechnicalSupportIntegrationTest.php`  (5/5)
- `php tests/InternationalizationUnitTest.php`  (5/5)
- `php tests/InternationalizationValidationTest.php` (5/5)

## Commits principaux
- `c9daaad` fix(assistance): technical support access, FAQ routing and i18n coverage
- `d933f08` merge: promote assistance fixes from groupe_assistance to pre-product
