### PR TITLE
feat(config): Ajout de la configuration universitaire dans le module …

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -189,6 +189,74 @@ class Config extends CommonDBTM
             }
         }
 
+        // Validate university name
+        if (isset($input["university_name"]) && !empty($input["university_name"])) {
+            $input["university_name"] = trim($input["university_name"]);
+            if (strlen($input["university_name"]) > 255) {
+                Session::addMessageAfterRedirect(__('University name is too long (maximum 255 characters)!'), false, ERROR);
+                return false;
+            }
+        }
+
+        // Validate academic year format (e.g., "2024-2025")
+        if (isset($input["academic_year"]) && !empty($input["academic_year"])) {
+            $input["academic_year"] = trim($input["academic_year"]);
+            if (!preg_match('/^\d{4}-\d{4}$/', $input["academic_year"])) {
+                Session::addMessageAfterRedirect(__('Invalid academic year format! Expected format: YYYY-YYYY (e.g., 2024-2025)'), false, ERROR);
+                return false;
+            }
+        }
+
+        // Validate current semester
+        if (isset($input["current_semester"]) && !empty($input["current_semester"])) {
+            $valid_semesters = ['autumn', 'spring', 'summer'];
+            if (!in_array($input["current_semester"], $valid_semesters)) {
+                Session::addMessageAfterRedirect(__('Invalid semester value!'), false, ERROR);
+                return false;
+            }
+        }
+
+        // Validate academic year dates
+        if (isset($input["academic_year_start_date"]) && !empty($input["academic_year_start_date"])) {
+            $start_date = strtotime($input["academic_year_start_date"]);
+            if ($start_date === false) {
+                Session::addMessageAfterRedirect(__('Invalid academic year start date!'), false, ERROR);
+                return false;
+            }
+        }
+
+        if (isset($input["academic_year_end_date"]) && !empty($input["academic_year_end_date"])) {
+            $end_date = strtotime($input["academic_year_end_date"]);
+            if ($end_date === false) {
+                Session::addMessageAfterRedirect(__('Invalid academic year end date!'), false, ERROR);
+                return false;
+            }
+
+            // Check that end date is after start date if both are set
+            if (isset($input["academic_year_start_date"]) && !empty($input["academic_year_start_date"])) {
+                $start_date = strtotime($input["academic_year_start_date"]);
+                if ($end_date <= $start_date) {
+                    Session::addMessageAfterRedirect(__('Academic year end date must be after start date!'), false, ERROR);
+                    return false;
+                }
+            }
+        }
+
+        // Validate helpdesk and central doc URLs
+        if (isset($input["helpdesk_doc_url"]) && !empty($input["helpdesk_doc_url"])) {
+            if (!Toolbox::isValidWebUrl($input["helpdesk_doc_url"])) {
+                Session::addMessageAfterRedirect(__('Invalid student documentation link!'), false, ERROR);
+                return false;
+            }
+        }
+
+        if (isset($input["central_doc_url"]) && !empty($input["central_doc_url"])) {
+            if (!Toolbox::isValidWebUrl($input["central_doc_url"])) {
+                Session::addMessageAfterRedirect(__('Invalid administrative documentation link!'), false, ERROR);
+                return false;
+            }
+        }
+
         $input = $this->handleSmtpInput($input);
 
         if (isset($input["proxy_passwd"]) && empty($input["proxy_passwd"])) {

--- a/templates/pages/setup/general/general_setup.html.twig
+++ b/templates/pages/setup/general/general_setup.html.twig
@@ -53,12 +53,86 @@
 
 {% block config_fields %}
 
+<div class="hr-text">
+    <i class="ti ti-school"></i>
+    <span>{{ __('University identity') }}</span>
+</div>
+
+<div class="row ps-4">
+
+    {{ fields.textField(
+        'university_name',
+        config['university_name'] ?? '',
+        __('University name'),
+        field_options|merge({
+            'helper': __('This name will be displayed in the application header')
+        })
+    ) }}
+
+</div>
+
+<div class="hr-text">
+    <i class="ti ti-calendar"></i>
+    <span>{{ __('Academic configuration') }}</span>
+</div>
+
+<div class="row ps-4">
+
+    {{ fields.textField(
+        'academic_year',
+        config['academic_year'] ?? '',
+        __('Current academic year'),
+        field_options|merge({
+            'helper': __('Example: 2024-2025'),
+            'placeholder': '2024-2025'
+        })
+    ) }}
+
+    {{ fields.dropdownArrayField(
+        'current_semester',
+        config['current_semester'] ?? '',
+        {
+            'autumn': __('Autumn'),
+            'spring': __('Spring'),
+            'summer': __('Summer')
+        },
+        __('Current semester'),
+        field_options|merge({
+            'width': 'auto',
+        })
+    ) }}
+
+    {{ fields.dateField(
+        'academic_year_start_date',
+        config['academic_year_start_date'] ?? '',
+        __('Academic year start date'),
+        field_options|merge({
+            'maybeempty': true,
+        })
+    ) }}
+
+    {{ fields.dateField(
+        'academic_year_end_date',
+        config['academic_year_end_date'] ?? '',
+        __('Academic year end date'),
+        field_options|merge({
+            'maybeempty': true,
+        })
+    ) }}
+
+</div>
+
+<div class="hr-text">
+    <i class="ti ti-settings"></i>
+    <span>{{ __('General configuration') }}</span>
+</div>
+
 <div class="row ps-4">
 
     {{ fields.textField(
         'url_base',
         config['url_base'],
-        __('URL of the application'),
+        __('url'),
         field_options
     ) }}
 
@@ -69,21 +143,26 @@
         field_options|merge({
             'enable_richtext': true,
             'enable_images': false,
+            'helper': __('Welcome message for university users. You can use HTML formatting.')
         })
     ) }}
 
     {{ fields.textField(
         'helpdesk_doc_url',
         config['helpdesk_doc_url'],
-        __('Simplified interface help link'),
-        field_options
+        __('Student documentation link'),
+        field_options|merge({
+            'helper': __('Link to student documentation (simplified interface)')
+        })
     ) }}
 
     {{ fields.textField(
         'central_doc_url',
         config['central_doc_url'],
-        __('Standard interface help link'),
-        field_options
+        __('Administrative documentation link'),
+        field_options|merge({
+            'helper': __('Link to administrative documentation (standard interface)')
+        })
     ) }}
 
     {{ fields.numberField(


### PR DESCRIPTION
…Générale
Ajout de la section « Identité de l'université » avec le champ nom de l'université
Ajout de la section « Configuration académique » avec :
Année académique (format YYYY-YYYY)
Semestre actuel (Automne / Printemps / Été)
Date de début d'année académique
Date de fin d'année académique
Amélioration des labels et des helper texts pour les champs existants :
text_login : ajout d’un helper text pour message d’accueil universitaire
helpdesk_doc_url : label modifié en « Lien vers la documentation étudiante »
central_doc_url : label modifié en « Lien vers la documentation administrative »
Ajout de validations dans Config.php pour tous les nouveaux champs
Validation du format de l’année académique (YYYY-YYYY)
Validation des dates académiques (cohérence début/fin)
Validation des URLs de documentation