### PR TITLE
Adaptation du sous-module Configuration – composants UNH

### DIFF
--- a/inc/define.php
+++ b/inc/define.php
@@ -320,10 +320,10 @@ $CFG_GLPI['networkport_instantiations']   = ['NetworkPortEthernet', 'NetworkPort
 
 $CFG_GLPI['device_types']                 = ['DeviceMotherboard', 'DeviceFirmware', 'DeviceProcessor',
     'DeviceMemory', 'DeviceHardDrive', 'DeviceNetworkCard',
-    'DeviceDrive', 'DeviceBattery', 'DeviceGraphicCard',
-    'DeviceSoundCard', 'DeviceControl', 'DevicePci',
-    'DeviceCase', 'DevicePowerSupply', 'DeviceGeneric',
-    'DeviceSimcard', 'DeviceSensor', 'DeviceCamera'
+    /*'DeviceDrive',*/ 'DeviceBattery', 'DeviceGraphicCard',
+    'DeviceSoundCard', 'DeviceControl', /*'DevicePci',
+    'DeviceCase', /*'DevicePowerSupply'*/ 'DeviceGeneric',
+    /*'DeviceSimcard'*/ 'DeviceSensor', 'DeviceCamera'
 ];
 
 

--- a/src/DeviceControl.php
+++ b/src/DeviceControl.php
@@ -40,21 +40,22 @@ class DeviceControl extends CommonDevice
 {
     protected static $forward_entity_to = ['Item_DeviceControl', 'Infocom'];
 
+
     public static function getTypeName($nb = 0)
     {
         return _n('Controller', 'Controllers', $nb);
     }
-
 
     public function getAdditionalFields()
     {
 
         return array_merge(
             parent::getAdditionalFields(),
-            [['name'  => 'is_raid',
-                'label' => __('RAID'),
-                'type'  => 'bool'
-            ],
+            [
+                ['name'  => 'is_raid',
+                    'label' => __('RAID'),
+                    'type'  => 'bool'
+                ],
                 ['name'  => 'interfacetypes_id',
                     'label' => __('Interface'),
                     'type'  => 'dropdownValue'

--- a/src/DeviceMemory.php
+++ b/src/DeviceMemory.php
@@ -40,7 +40,7 @@ class DeviceMemory extends CommonDevice
 
     public static function getTypeName($nb = 0)
     {
-        return _n('Memory', 'Memory', $nb);
+        return _n('Serveur', 'Serveur', $nb);
     }
 
 
@@ -51,22 +51,18 @@ class DeviceMemory extends CommonDevice
             parent::getAdditionalFields(),
             [
                 [
-                    'name'  => 'size_default',
-                    'label' => __('Size by default'),
-                    'type'  => 'integer',
-                    'min'   => 0,
-                    'unit'  => __('Mio')
+                    'name'  => 'serial_number',
+                    'label' => __('Serial Number'),
+                    'type'  => 'text'
                 ],
                 [
-                    'name'  => 'frequence',
-                    'label' => __('Frequency'),
-                    'type'  => 'integer',
-                    'min'   => 0,
-                    'unit'  => __('MHz')
+                    'name'  => 'commissioning_date',
+                    'label' => __('Commissioning Date'),
+                    'type'  => 'date'
                 ],
                 [
-                    'name'  => 'devicememorytypes_id',
-                    'label' => _n('Type', 'Types', 1),
+                    'name'  => 'status',
+                    'label' => __('Status'),
                     'type'  => 'dropdownValue'
                 ],
                 [
@@ -84,27 +80,27 @@ class DeviceMemory extends CommonDevice
         $tab = parent::rawSearchOptions();
 
         $tab[] = [
-            'id'                 => '11',
+            'id'                 => '15',
             'table'              => $this->getTable(),
-            'field'              => 'size_default',
-            'name'               => __('Size by default'),
-            'datatype'           => 'integer',
+            'field'              => 'serial_number',
+            'name'               => __('Serial Number'),
+            'datatype'           => 'string',
         ];
 
         $tab[] = [
-            'id'                 => '12',
+            'id'                 => '17', // Updated to avoid duplicate ID
             'table'              => $this->getTable(),
-            'field'              => 'frequence',
-            'name'               => __('Frequency'),
-            'datatype'           => 'integer',
+            'field'              => 'commissioning_date',
+            'name'               => __('Commissioning Date'),
+            'datatype'           => 'date',
         ];
 
         $tab[] = [
-            'id'                 => '13',
-            'table'              => 'glpi_devicememorytypes',
-            'field'              => 'name',
-            'name'               => _n('Type', 'Types', 1),
-            'datatype'           => 'dropdown'
+            'id'                 => '18',
+            'table'              => $this->getTable(),
+            'field'              => 'status',
+            'name'               => __('Status'),
+            'datatype'           => 'dropdown',
         ];
 
         $tab[] = [

--- a/src/DevicePci.php
+++ b/src/DevicePci.php
@@ -40,11 +40,12 @@ class DevicePci extends CommonDevice
 {
     protected static $forward_entity_to = ['Item_DevicePci', 'Infocom'];
 
+    
     public static function getTypeName($nb = 0)
     {
         return _n('PCI device', 'PCI devices', $nb);
     }
-
+   
 
     /**
      * @see CommonDevice::getAdditionalFields()

--- a/src/DevicePowerSupply.php
+++ b/src/DevicePowerSupply.php
@@ -38,11 +38,12 @@ class DevicePowerSupply extends CommonDevice
 {
     protected static $forward_entity_to = ['Item_DevicePowerSupply', 'Infocom'];
 
+    
     public static function getTypeName($nb = 0)
     {
         return _n('Power supply', 'Power supplies', $nb);
     }
-
+    
 
     public function getAdditionalFields()
     {


### PR DESCRIPTION
Cette modification consiste à adapter le sous-module Configuration → Composants de GLPI aux besoins réels de l’Université UNH, en conservant uniquement les composants matériels pertinents pour l’inventaire et la maintenance du parc informatique, tout en simplifiant ou en écartant les éléments non essentiels afin d’améliorer la lisibilité, l’efficacité et l’usage du système.