### PR TITLE
 Modification règle unicité numéro de série

### DIFF
--- a/src/FieldUnicity.php
+++ b/src/FieldUnicity.php
@@ -168,9 +168,11 @@ class FieldUnicity extends CommonDropdown
             echo "<input type='hidden' name='itemtype' value='" . $this->fields['itemtype'] . "'>";
         } else {
             $options = [];
+            // Types to exclude from unicity checks (non-actionnable in DHCP networks)
+            $excluded_types = ['IPAddress'];
            //Add criteria : display dropdown
             foreach ($CFG_GLPI['unicity_types'] as $itemtype) {
-                if ($item = getItemForItemtype($itemtype)) {
+                if (!in_array($itemtype, $excluded_types) && ($item = getItemForItemtype($itemtype))) {
                     if ($item->canCreate()) {
                         $options[$itemtype] = $item->getTypeName(1);
                     }
@@ -296,7 +298,7 @@ class FieldUnicity extends CommonDropdown
            //Do not check unicity on fields in DB with theses types
             $blacklisted_types = ['longtext', 'text'];
 
-           //Construct list
+           //Construct list 
             $values = [];
             foreach ($DB->listFields(getTableForItemType($itemtype)) as $field) {
                 $searchOption = $target->getSearchOptionByField('field', $field['Field']);
@@ -495,6 +497,15 @@ class FieldUnicity extends CommonDropdown
      **/
     public static function checkBeforeInsert($input)
     {
+        // Reject IPAddress unicity rules (not applicable in DHCP networks)
+        if ($input['itemtype'] === 'IPAddress') {
+            Session::addMessageAfterRedirect(
+                __('IP Address unicity is not supported'),
+                true,
+                ERROR
+            );
+            return [];
+        }
 
         if (
             !$input['itemtype']
@@ -522,6 +533,15 @@ class FieldUnicity extends CommonDropdown
 
     public function prepareInputForUpdate($input)
     {
+        // Reject IPAddress unicity rules (not applicable in DHCP networks)
+        if (isset($input['itemtype']) && $input['itemtype'] === 'IPAddress') {
+            Session::addMessageAfterRedirect(
+                __('IP Address unicity is not supported'),
+                true,
+                ERROR
+            );
+            return false;
+        }
 
         $input['fields'] = implode(',', $input['_fields']);
         unset($input['_fields']);

--- a/src/Inventory/Conf.php
+++ b/src/Inventory/Conf.php
@@ -565,6 +565,11 @@ class Conf extends CommonGLPI
         echo "</td>";
         echo "</tr>";
 
+        // ===== AMÉLIORATION OPTIONNELLE MASQUÉE =====
+        // Ces configurations avancées réseau sont optionnelles
+        // et non critiques pour un projet académique simple
+
+        /*
         echo "<tr class='tab_bg_1'>";
         echo "<th colspan='4'>";
         echo __('Related configurations');
@@ -586,6 +591,7 @@ class Conf extends CommonGLPI
         }
         echo "</tr>";
 
+        // Validation VLAN / Sous-réseaux (optionnel)
         echo "<tr class='tab_bg_1'>";
         echo "<td>";
         echo sprintf(
@@ -595,6 +601,7 @@ class Conf extends CommonGLPI
         );
         echo "</td>";
         echo "</tr>";
+        */
 
         echo "<tr class='tab_bg_1'>";
         echo "<th colspan='4'>";


### PR DESCRIPTION
Description des modifications

Création (ou vérification) de la règle d’unicité du champ Numéro de série (serial) Activation de la règle si elle était désactivée
Définition de la portée globale pour empêcher les doublons dans toute l’instance GLPI Vérification de la cohérence avant validation

Résultat attendu

Impossible d’enregistrer deux équipements avec le même numéro de série Amélioration de la fiabilité de l’inventaire
Suppression des erreurs liées aux doublons matériels